### PR TITLE
Deprecate EL6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ jobs:
     docker:
       - image: circleci/python:2.7
     environment:
-      DISTROS: trusty xenial bionic el6 el7 el8
-      DOCKER_DISTROS: trusty bionic centos6 centos7 centos8
+      DISTROS: trusty xenial bionic el7 el8
+      DOCKER_DISTROS: trusty bionic centos7 centos8
       DOCKER_RUN: |-
         docker run -w /code/st2-sso-backend --volumes-from st2-sso-backend-vol
             -e PKG_VERSION=$PKG_VERSION
@@ -130,13 +130,10 @@ jobs:
             eval ${DOCKER_RUN} stackstorm/buildpack:bionic make play deb
             docker cp st2-sso-backend-vol:/code/st2-sso-backend_${PKG_VERSION}-${PKG_RELEASE}_amd64.deb ~/st2-sso-backend/build/bionic
             docker cp st2-sso-backend-vol:/code/st2-sso-backend_${PKG_VERSION}-${PKG_RELEASE}_amd64.changes ~/st2-sso-backend/build/bionic
-            # 3. Build RHEL 6 packages
-            eval ${DOCKER_RUN} stackstorm/buildpack:centos6 make play rpm
-            docker cp st2-sso-backend-vol:/code/st2-sso-backend/build/x86_64/st2-sso-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-sso-backend/build/el6
-            # 4. Build RHEL 7 packages
+            # 3. Build RHEL 7 packages
             eval ${DOCKER_RUN} stackstorm/buildpack:centos7 make play rpm
             docker cp st2-sso-backend-vol:/code/st2-sso-backend/build/x86_64/st2-sso-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-sso-backend/build/el7
-            # 5. Build RHEL 8 packages
+            # 4. Build RHEL 8 packages
             eval ${DOCKER_RUN} stackstorm/buildpack:centos8 make play rpm
             docker cp st2-sso-backend-vol:/code/st2-sso-backend/build/x86_64/st2-sso-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-sso-backend/build/el8
             # List poduced artifacts
@@ -155,7 +152,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: /tmp/deploy
     environment:
-      DISTROS: trusty xenial bionic el6 el7 el8
+      DISTROS: trusty xenial bionic el7 el8
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
CentOS 6 / RHEL 6 are to be fully deprecated. Remove the EL6 specific builds. 